### PR TITLE
Support for setting many bundles as template resource resolver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>2.0.18</version>
+            <version>2.0.21</version>
         </dependency>
         <dependency>
             <groupId>ognl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>DeepaMehta 4 Web Activator</name>
     <groupId>de.deepamehta</groupId>
     <artifactId>dm46-webactivator</artifactId>
-    <version>0.4.5</version>
+    <version>0.4.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>DeepaMehta 4 Thymeleaf</name>
     <groupId>de.deepamehta</groupId>
     <artifactId>dm48-thymeleaf</artifactId>
-    <version>0.5</version>
+    <version>0.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <name>DeepaMehta 4 Web Activator</name>
     <groupId>de.deepamehta</groupId>
-    <artifactId>dm44-webactivator</artifactId>
-    <version>0.4.4</version>
+    <artifactId>dm46-webactivator</artifactId>
+    <version>0.4.5</version>
     <packaging>bundle</packaging>
 
     <parent>
         <groupId>de.deepamehta</groupId>
         <artifactId>deepamehta-plugin-parent</artifactId>
-        <version>4.4</version>
+        <version>4.6</version>
     </parent>
 
     <dependencies>

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -105,11 +105,11 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
         // ### Apply template file name pattern conventions under "/views" if you want to optimize performance
         // Hint: http://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#template-resolvers
         if (additionalTemplateResourceBundles.size() > 0) {
-            logger.info("Initializing thymeleaf Template engine with additional template resolver bundles...");
+            logger.info("Initializing Thymeleaf TemplateEngine with additional template resolver bundles...");
             int order = 2;
             for (Bundle otherTemplateResourceBundle : additionalTemplateResourceBundles) {
                 TemplateResolver otherTemplateResolver = new TemplateResolver();
-                logger.info("Added template resolver for bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
+                logger.info("Added template resolver bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
                 otherTemplateResolver.setResourceResolver(new BundleResourcesResolver(otherTemplateResourceBundle));
                 otherTemplateResolver.setOrder(order);
                 templateEngine.addTemplateResolver(otherTemplateResolver);
@@ -119,7 +119,7 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
             // to not "stand in the way" of valid template file names but fallback to e.g. "404.html", or "page.html".
             webpagesTemplateResolver.setOrder(order+1);
         } else {
-            logger.info("Initializing thymeleaf Template engine just with our standard webpages template resolver bundle...");
+            logger.info("Initializing Thymeleaf TemplateEngine without any additional template resolver bundles...");
         }
     }
 

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -24,6 +24,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 
 import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Logger;
 
 
@@ -40,6 +42,8 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
     // ---------------------------------------------------------------------------------------------- Instance Variables
 
     private TemplateEngine templateEngine;
+    Set<Bundle> additionalTemplateResourceBundles = new HashSet<Bundle>();
+
 
     @Context private HttpServletRequest request;
     @Context private HttpServletResponse response;
@@ -80,16 +84,43 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
         return templateEngine;
     }
 
-
-
     // ----------------------------------------------------------------------------------------------- Protected Methods
 
+    protected void addTemplateResourceBundle(Bundle templateBundleResource) {
+        additionalTemplateResourceBundles.add(templateBundleResource);
+    }
+
+    protected void removeTemplateResourceBundle(Bundle templateBundleResource) {
+        additionalTemplateResourceBundles.remove(templateBundleResource);
+    }
+
     protected void initTemplateEngine() {
-        TemplateResolver templateResolver = new TemplateResolver();
-        templateResolver.setResourceResolver(new BundleResourcesResolver(bundle));
-        //
+        // Initialize this plugin bundle (extending ThymeLeafPlugin) as the default BundleResourceResolver
+        TemplateResolver webpagesTemplateResolver = new TemplateResolver();
+        webpagesTemplateResolver.setResourceResolver(new BundleResourcesResolver(bundle));
+        webpagesTemplateResolver.setOrder(1);
         templateEngine = new TemplateEngine();
-        templateEngine.setTemplateResolver(templateResolver);
+        templateEngine.addTemplateResolver(webpagesTemplateResolver);
+        // If configured set Additional BundleResourceResolver and give them priority in template resolution
+        // ### Apply template file name pattern conventions under "/views" if you want to optimize performance
+        // Hint: http://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#template-resolvers
+        if (additionalTemplateResourceBundles.size() > 0) {
+            logger.info("Initializing thymeleaf Template engine with additional template resolver bundles...");
+            int order = 2;
+            for (Bundle otherTemplateResourceBundle : additionalTemplateResourceBundles) {
+                TemplateResolver otherTemplateResolver = new TemplateResolver();
+                logger.info("Added template resolver for bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
+                otherTemplateResolver.setResourceResolver(new BundleResourcesResolver(otherTemplateResourceBundle));
+                otherTemplateResolver.setOrder(order);
+                templateEngine.addTemplateResolver(otherTemplateResolver);
+                order++;
+            }
+            // if other bundles are present we override our "order" to being the template resovler with lowest priority
+            // to not "stand in the way" of valid template file names but fallback to e.g. "404.html", or "page.html".
+            webpagesTemplateResolver.setOrder(order+1);
+        } else {
+            logger.info("Initializing thymeleaf Template engine just with our standard webpages template resolver bundle...");
+        }
     }
 
     protected void viewData(String name, Object value) {

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -102,8 +102,6 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
         templateEngine = new TemplateEngine();
         templateEngine.addTemplateResolver(webpagesTemplateResolver);
         // If configured set Additional BundleResourceResolver and give them priority in template resolution
-        // ### Apply template file name pattern conventions under "/views" if you want to optimize performance
-        // Hint: http://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#template-resolvers
         if (additionalTemplateResourceBundles.size() > 0) {
             logger.info("Initializing Thymeleaf TemplateEngine with additional template resolver bundles...");
             int order = 2;

--- a/src/main/java/de/deepamehta/thymeleaf/provider/ThymeleafViewProcessor.java
+++ b/src/main/java/de/deepamehta/thymeleaf/provider/ThymeleafViewProcessor.java
@@ -46,7 +46,7 @@ public class ThymeleafViewProcessor implements ViewProcessor<String> {
     @Override
     public void writeTo(String templateName, Viewable viewable, OutputStream out) throws IOException {
         ThymeleafPlugin plugin = matchedPlugin();
-        logger.info("Processing template \"" + templateName + "\" of " + plugin);
+        logger.info("Processing template \"" + templateName + "\" with TemplateEngine of " + plugin);
         processTemplate(plugin.getTemplateEngine(), templateName, (IContext) viewable.getModel(), out);
     }
 


### PR DESCRIPTION
This allows one or more other DeepaMehta 4 plugins to be registered as additional `BundleResourcesResolver`, making their template files in their `/views/` folder resource effectively available to be processed by a request to the other plugins resource.

I am not sure if this is what we would want in the long term but it is necessary to fulfill the following requirements:
- the [dm4-webpages](https://github.com/mukil/dm4-webpages) module (greedily) claiming the "/" resource of a DeepaMehta 4 installation
- the [dm4-kiezatlas-website](https://github.com/mukil/dm4-kiezatlas-website) module actually serving the template and viewData for that resource

The way it is now is that, if there were additional bundle resources announced for containing templates to resolve, those have precedence. So the ThymeleafPlugins templates are resolved as a last resort, effectively allowing for an override of templates, which is what i would expect.

I would be happy for a review or comments on room for improvement (as their def. is some) but i would also be happy to have it as it is included in the upcoming 0.6 release.

Thanks & Cheers!