### PR TITLE
make use of setPrefix and setSuffix simplifies resolving of fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Thymeleaf template engine:
 Version History
 ---------------
 
+**0.6** -- Upcoming
+
+* Support for setting up many BundleResourceResolvers
+* Resolve included th:fragments by their template name only
+* Minor thymeleaf version update: 2.0.18 > 2.0.21
+
 **0.5** -- Apr 17, 2016
 
 * Renamed from "DM4 Web Activator" to "DM4 Thymeleaf".

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Version History
 
 * Support for setting up many BundleResourceResolvers
 * Resolve included th:fragments by their template name only
-* Minor thymeleaf version update: 2.0.18 > 2.0.21
+* Thymeleaf Upgrade: 2.0.18 > 2.1.3
 
 **0.5** -- Apr 17, 2016
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>2.0.18</version>
+            <version>2.0.21</version>
         </dependency>
         <dependency>
             <groupId>ognl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>DeepaMehta 4 Web Activator</name>
     <groupId>de.deepamehta</groupId>
     <artifactId>dm46-webactivator</artifactId>
-    <version>0.4.5</version>
+    <version>0.4.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>DeepaMehta 4 Thymeleaf</name>
     <groupId>de.deepamehta</groupId>
     <artifactId>dm48-thymeleaf</artifactId>
-    <version>0.5</version>
+    <version>0.6-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,18 @@
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
-            <version>2.0.21</version>
+            <version>2.1.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>ognl</groupId>
             <artifactId>ognl</artifactId>
             <version>3.0.6</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.unbescape</groupId>
+            <artifactId>unbescape</artifactId>
+            <version>1.1.3.RELEASE</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -53,7 +59,7 @@
                             !org.cyberneko.html, !org.apache.xerces.*, !com.sun.jdi.*, *
                         </Import-Package>
                         <Embed-Dependency>
-                            thymeleaf, ognl, javassist
+                            thymeleaf, ognl, javassist, unbescape
                         </Embed-Dependency>
                     </instructions>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <name>DeepaMehta 4 Web Activator</name>
     <groupId>de.deepamehta</groupId>
-    <artifactId>dm44-webactivator</artifactId>
-    <version>0.4.4</version>
+    <artifactId>dm46-webactivator</artifactId>
+    <version>0.4.5</version>
     <packaging>bundle</packaging>
 
     <parent>
         <groupId>de.deepamehta</groupId>
         <artifactId>deepamehta-plugin-parent</artifactId>
-        <version>4.4</version>
+        <version>4.6</version>
     </parent>
 
     <dependencies>

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -105,11 +105,11 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
         // ### Apply template file name pattern conventions under "/views" if you want to optimize performance
         // Hint: http://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#template-resolvers
         if (additionalTemplateResourceBundles.size() > 0) {
-            logger.info("Initializing thymeleaf Template engine with additional template resolver bundles...");
+            logger.info("Initializing Thymeleaf TemplateEngine with additional template resolver bundles...");
             int order = 2;
             for (Bundle otherTemplateResourceBundle : additionalTemplateResourceBundles) {
                 TemplateResolver otherTemplateResolver = new TemplateResolver();
-                logger.info("Added template resolver for bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
+                logger.info("Added template resolver bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
                 otherTemplateResolver.setResourceResolver(new BundleResourcesResolver(otherTemplateResourceBundle));
                 otherTemplateResolver.setOrder(order);
                 templateEngine.addTemplateResolver(otherTemplateResolver);
@@ -119,7 +119,7 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
             // to not "stand in the way" of valid template file names but fallback to e.g. "404.html", or "page.html".
             webpagesTemplateResolver.setOrder(order+1);
         } else {
-            logger.info("Initializing thymeleaf Template engine just with our standard webpages template resolver bundle...");
+            logger.info("Initializing Thymeleaf TemplateEngine without any additional template resolver bundles...");
         }
     }
 

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -24,6 +24,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
 
 import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.logging.Logger;
 
 
@@ -40,6 +42,8 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
     // ---------------------------------------------------------------------------------------------- Instance Variables
 
     private TemplateEngine templateEngine;
+    Set<Bundle> additionalTemplateResourceBundles = new HashSet<Bundle>();
+
 
     @Context private HttpServletRequest request;
     @Context private HttpServletResponse response;
@@ -80,16 +84,43 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
         return templateEngine;
     }
 
-
-
     // ----------------------------------------------------------------------------------------------- Protected Methods
 
+    protected void addTemplateResourceBundle(Bundle templateBundleResource) {
+        additionalTemplateResourceBundles.add(templateBundleResource);
+    }
+
+    protected void removeTemplateResourceBundle(Bundle templateBundleResource) {
+        additionalTemplateResourceBundles.remove(templateBundleResource);
+    }
+
     protected void initTemplateEngine() {
-        TemplateResolver templateResolver = new TemplateResolver();
-        templateResolver.setResourceResolver(new BundleResourcesResolver(bundle));
-        //
+        // Initialize this plugin bundle (extending ThymeLeafPlugin) as the default BundleResourceResolver
+        TemplateResolver webpagesTemplateResolver = new TemplateResolver();
+        webpagesTemplateResolver.setResourceResolver(new BundleResourcesResolver(bundle));
+        webpagesTemplateResolver.setOrder(1);
         templateEngine = new TemplateEngine();
-        templateEngine.setTemplateResolver(templateResolver);
+        templateEngine.addTemplateResolver(webpagesTemplateResolver);
+        // If configured set Additional BundleResourceResolver and give them priority in template resolution
+        // ### Apply template file name pattern conventions under "/views" if you want to optimize performance
+        // Hint: http://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#template-resolvers
+        if (additionalTemplateResourceBundles.size() > 0) {
+            logger.info("Initializing thymeleaf Template engine with additional template resolver bundles...");
+            int order = 2;
+            for (Bundle otherTemplateResourceBundle : additionalTemplateResourceBundles) {
+                TemplateResolver otherTemplateResolver = new TemplateResolver();
+                logger.info("Added template resolver for bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
+                otherTemplateResolver.setResourceResolver(new BundleResourcesResolver(otherTemplateResourceBundle));
+                otherTemplateResolver.setOrder(order);
+                templateEngine.addTemplateResolver(otherTemplateResolver);
+                order++;
+            }
+            // if other bundles are present we override our "order" to being the template resovler with lowest priority
+            // to not "stand in the way" of valid template file names but fallback to e.g. "404.html", or "page.html".
+            webpagesTemplateResolver.setOrder(order+1);
+        } else {
+            logger.info("Initializing thymeleaf Template engine just with our standard webpages template resolver bundle...");
+        }
     }
 
     protected void viewData(String name, Object value) {

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -38,6 +38,8 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
     // ------------------------------------------------------------------------------------------------------- Constants
 
     private static String ATTR_CONTEXT = "de.deepamehta.thymeleaf.Context";
+    private static String TEMPLATES_FOLDER = "/views/";
+    private static String TEMPLATES_ENDING = ".html";
 
     // ---------------------------------------------------------------------------------------------- Instance Variables
 
@@ -99,6 +101,8 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
         TemplateResolver webpagesTemplateResolver = new TemplateResolver();
         webpagesTemplateResolver.setResourceResolver(new BundleResourcesResolver(bundle));
         webpagesTemplateResolver.setOrder(1);
+        webpagesTemplateResolver.setPrefix(TEMPLATES_FOLDER);
+        webpagesTemplateResolver.setSuffix(TEMPLATES_ENDING);
         templateEngine = new TemplateEngine();
         templateEngine.addTemplateResolver(webpagesTemplateResolver);
         // If configured set Additional BundleResourceResolver and give them priority in template resolution
@@ -110,6 +114,8 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
                 logger.info("Added template resolver bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
                 otherTemplateResolver.setResourceResolver(new BundleResourcesResolver(otherTemplateResourceBundle));
                 otherTemplateResolver.setOrder(order);
+                otherTemplateResolver.setPrefix(TEMPLATES_FOLDER);
+                otherTemplateResolver.setSuffix(TEMPLATES_ENDING);
                 templateEngine.addTemplateResolver(otherTemplateResolver);
                 order++;
             }

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -102,8 +102,6 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
         templateEngine = new TemplateEngine();
         templateEngine.addTemplateResolver(webpagesTemplateResolver);
         // If configured set Additional BundleResourceResolver and give them priority in template resolution
-        // ### Apply template file name pattern conventions under "/views" if you want to optimize performance
-        // Hint: http://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#template-resolvers
         if (additionalTemplateResourceBundles.size() > 0) {
             logger.info("Initializing Thymeleaf TemplateEngine with additional template resolver bundles...");
             int order = 2;

--- a/src/main/java/de/deepamehta/thymeleaf/provider/ThymeleafViewProcessor.java
+++ b/src/main/java/de/deepamehta/thymeleaf/provider/ThymeleafViewProcessor.java
@@ -46,7 +46,7 @@ public class ThymeleafViewProcessor implements ViewProcessor<String> {
     @Override
     public void writeTo(String templateName, Viewable viewable, OutputStream out) throws IOException {
         ThymeleafPlugin plugin = matchedPlugin();
-        logger.info("Processing template \"" + templateName + "\" of " + plugin);
+        logger.info("Processing template \"" + templateName + "\" with TemplateEngine of " + plugin);
         processTemplate(plugin.getTemplateEngine(), templateName, (IContext) viewable.getModel(), out);
     }
 

--- a/src/main/java/de/deepamehta/thymeleaf/provider/ThymeleafViewProcessor.java
+++ b/src/main/java/de/deepamehta/thymeleaf/provider/ThymeleafViewProcessor.java
@@ -40,7 +40,7 @@ public class ThymeleafViewProcessor implements ViewProcessor<String> {
         // Note: By default the Viewable constructor resolves relative template names (as returned by the
         // webapp's resource methods) against the package path of the request's matching resource object.
         // JavaUtils.getFilename() strips that path.
-        return "/views/" + JavaUtils.getFilename(templateName) + ".html";
+        return JavaUtils.getFilename(templateName);
     }
 
     @Override


### PR DESCRIPTION
On top of my other pull request which i know is less than ideal (because they could be applied independently), i have this one as clear improvement for our current template engine resolver configuration.

At the moment we hardcoded the "/views/" path and the file suffix ".html" in the `resolve` method of the `ThymeleafViewProcessor`, which is totally fine except that it does not seem to be in the loop when the template resolver resolves templates from within other templates (done within `templateEngine.process(...)` i guess).

So the current way to successfully reference `th:fragments` from within other templates is:
```
th:fragment="/views/partials.html :: navigation"
```
while it is expected to be written simply as
```
th:fragment="partials :: navigation"
```

This lead me to the observation described above.
Now, using the following [reference](http://www.thymeleaf.org/doc/tutorials/2.1/usingthymeleaf.html#defining-and-referencing-fragments) i found out about the `setPrefix` and `setSuffix` configuration option for any resolver and that using those might solve this issue.
```
templateResolver.setPrefix("/views/");
templateResolver.setSuffix(".html");
```
And it did. Fragments are now resolved from within other templates without providing any additional path pre and file name suffix in the "th:fragments" call. Subsequently there was no further need to hard code the paths into `resolve` method of the `ThymelleafViewProcessor` implementation, thus these could be removed too.


