### PR TITLE
0.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Version History
 
 **0.6** -- Upcoming
 
-* Support for setting up many BundleResourceResolvers
+* Support for setting up many `BundleResourceResolvers`
 * Resolve included th:fragments by their template name only
 * Thymeleaf Upgrade: 2.0.18 > 2.1.3
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Thymeleaf template engine:
 Version History
 ---------------
 
-**0.6** -- Upcoming
+**0.6** -- Aug 04, 2016
 
 * Support for setting up many `BundleResourceResolvers`
 * Resolve included th:fragments by their template name only

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <name>DeepaMehta 4 Thymeleaf</name>
     <groupId>de.deepamehta</groupId>
     <artifactId>dm48-thymeleaf</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.6</version>
     <packaging>bundle</packaging>
 
     <parent>

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -98,11 +98,7 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
 
     protected void initTemplateEngine() {
         // Initialize this plugin bundle (extending ThymeLeafPlugin) as the default BundleResourceResolver
-        TemplateResolver webpagesTemplateResolver = new TemplateResolver();
-        webpagesTemplateResolver.setResourceResolver(new BundleResourcesResolver(bundle));
-        webpagesTemplateResolver.setOrder(1);
-        webpagesTemplateResolver.setPrefix(TEMPLATES_FOLDER);
-        webpagesTemplateResolver.setSuffix(TEMPLATES_ENDING);
+        TemplateResolver webpagesTemplateResolver = createBundleResourcesResolver(bundle, 1);
         templateEngine = new TemplateEngine();
         templateEngine.addTemplateResolver(webpagesTemplateResolver);
         // If configured set Additional BundleResourceResolver and give them priority in template resolution
@@ -110,17 +106,13 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
             logger.info("Initializing Thymeleaf TemplateEngine with additional template resolver bundles...");
             int order = 2;
             for (Bundle otherTemplateResourceBundle : additionalTemplateResourceBundles) {
-                TemplateResolver otherTemplateResolver = new TemplateResolver();
+                TemplateResolver otherTemplateResolver = createBundleResourcesResolver(otherTemplateResourceBundle, order);
                 logger.info("Added template resolver bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
-                otherTemplateResolver.setResourceResolver(new BundleResourcesResolver(otherTemplateResourceBundle));
-                otherTemplateResolver.setOrder(order);
-                otherTemplateResolver.setPrefix(TEMPLATES_FOLDER);
-                otherTemplateResolver.setSuffix(TEMPLATES_ENDING);
                 templateEngine.addTemplateResolver(otherTemplateResolver);
                 order++;
             }
-            // if other bundles are present we override our "order" to being the template resovler with lowest priority
-            // to not "stand in the way" of valid template file names but fallback to e.g. "404.html", or "page.html".
+            // if other bundle resolvers are present we override our order, giving the standard resolver lowest priority
+            // this is to to not "stand in the way" of valid template file names but fallback to e.g. the "404.html"
             webpagesTemplateResolver.setOrder(order+1);
         } else {
             logger.info("Initializing Thymeleaf TemplateEngine without any additional template resolver bundles...");
@@ -136,6 +128,15 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
     }
 
     // ------------------------------------------------------------------------------------------------- Private Methods
+
+    private TemplateResolver createBundleResourcesResolver(Bundle bundle, int order) {
+        TemplateResolver tr = new TemplateResolver();
+        tr.setResourceResolver(new BundleResourcesResolver(bundle));
+        tr.setOrder(order);
+        tr.setPrefix(TEMPLATES_FOLDER);
+        tr.setSuffix(TEMPLATES_ENDING);
+        return tr;
+    }
 
     private AbstractContext context() {
         return (AbstractContext) request.getAttribute(ATTR_CONTEXT);

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -97,22 +97,20 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
     }
 
     protected void initTemplateEngine() {
-        // If configured set Additional BundleResourceResolver and give them priority in template resolution
         templateEngine = new TemplateEngine();
-        int order = 1;
+        // 1) if configured set additional BundleResourceResolver we register them 1st, giving their resources priority
         if (additionalTemplateResourceBundles.size() > 0) {
             logger.info("Initializing Thymeleaf TemplateEngine with additional template resolver bundles...");
             for (Bundle otherTemplateResourceBundle : additionalTemplateResourceBundles) {
-                TemplateResolver otherTemplateResolver = createBundleResourcesResolver(otherTemplateResourceBundle, order);
+                TemplateResolver otherTemplateResolver = createBundleResourcesResolver(otherTemplateResourceBundle);
                 templateEngine.addTemplateResolver(otherTemplateResolver);
                 logger.info("Added template resolver bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
-                order++;
             }
         } else {
             logger.info("Initializing Thymeleaf TemplateEngine without any additional template resolver bundles...");
         }
-        // Initialize this plugin bundle (extending ThymeLeafPlugin) as a BundleResourceResolver too
-        templateEngine.addTemplateResolver(createBundleResourcesResolver(bundle, order));
+        // 2) initialize the "this" plugin (the one extending this class) as a BundleResourceResolver too
+        templateEngine.addTemplateResolver(createBundleResourcesResolver(bundle));
     }
 
     protected void viewData(String name, Object value) {
@@ -125,10 +123,9 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
 
     // ------------------------------------------------------------------------------------------------- Private Methods
 
-    private TemplateResolver createBundleResourcesResolver(Bundle bundle, int order) {
+    private TemplateResolver createBundleResourcesResolver(Bundle bundle) {
         TemplateResolver tr = new TemplateResolver();
         tr.setResourceResolver(new BundleResourcesResolver(bundle));
-        tr.setOrder(order);
         tr.setPrefix(TEMPLATES_FOLDER);
         tr.setSuffix(TEMPLATES_ENDING);
         return tr;
@@ -150,7 +147,7 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
 
         @Override
         public String getName() {
-            return "BundleResourcesResolver";
+            return bundle.getSymbolicName() + ".BundleResourcesResolver";
         }
 
         @Override

--- a/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
+++ b/src/main/java/de/deepamehta/thymeleaf/ThymeleafPlugin.java
@@ -97,26 +97,22 @@ public class ThymeleafPlugin extends PluginActivator implements ServiceRequestFi
     }
 
     protected void initTemplateEngine() {
-        // Initialize this plugin bundle (extending ThymeLeafPlugin) as the default BundleResourceResolver
-        TemplateResolver webpagesTemplateResolver = createBundleResourcesResolver(bundle, 1);
-        templateEngine = new TemplateEngine();
-        templateEngine.addTemplateResolver(webpagesTemplateResolver);
         // If configured set Additional BundleResourceResolver and give them priority in template resolution
+        templateEngine = new TemplateEngine();
+        int order = 1;
         if (additionalTemplateResourceBundles.size() > 0) {
             logger.info("Initializing Thymeleaf TemplateEngine with additional template resolver bundles...");
-            int order = 2;
             for (Bundle otherTemplateResourceBundle : additionalTemplateResourceBundles) {
                 TemplateResolver otherTemplateResolver = createBundleResourcesResolver(otherTemplateResourceBundle, order);
-                logger.info("Added template resolver bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
                 templateEngine.addTemplateResolver(otherTemplateResolver);
+                logger.info("Added template resolver bundle \"" + otherTemplateResourceBundle.getSymbolicName() + "\"");
                 order++;
             }
-            // if other bundle resolvers are present we override our order, giving the standard resolver lowest priority
-            // this is to to not "stand in the way" of valid template file names but fallback to e.g. the "404.html"
-            webpagesTemplateResolver.setOrder(order+1);
         } else {
             logger.info("Initializing Thymeleaf TemplateEngine without any additional template resolver bundles...");
         }
+        // Initialize this plugin bundle (extending ThymeLeafPlugin) as a BundleResourceResolver too
+        templateEngine.addTemplateResolver(createBundleResourcesResolver(bundle, order));
     }
 
     protected void viewData(String name, Object value) {


### PR DESCRIPTION
Thymeleaf now comes with support for setting up many template resource resolvers. This is far from ideal as it only allows us to configure, resolve and load template files over many bundles for a specific HTTP resource - however this allowed me to realize the following three use cases:
- the [dm4-sign-up](/mukil/dm4-sign-up) plugin allows other plugins, like the [dm4-kiezatlas-website](/mukil/dm4-kiezatlas-website) module to inject its own navigation menu and style (XHTML Template Fragment) into its templates (being the account registration, login and status pages). This is possible through a convention introduced by the dm4-sign-up module, placing ones own navigation fragment in a file called `/views/fragments/navigation.html`.
- the [dm4-webpages](/mukil/dm4-webpages) module allows others, like the the [dm4-kiezatlas-website](/mukil/dm4-kiezatlas-website) module to override its standard _404_ and _500_ HTML status pages (also through following a location filename convention: `/views/404.html` and `/views/500.hml`)
- the [dm4-webpages](/mukil/dm4-webpages) module allows others, like the the [dm4-kiezatlas-website](/mukil/dm4-kiezatlas-website) module to override the template loaded for the root `/` resource (which is managed by the dm4-webpages plugin after installation) through registering a template filename via a dedicated service call.

Please note: As soon as your plugin bundle (and with it its template file resources) goes away or come around the ThymleafPlugin governing the respective HTTP Resource must either allow your plugin (or make sure on its own) to call `initTemplateEngine()` again (in both cases).

The two modules mentioned above do so through implementing listeners for the `serviceGone` and `serviceArrived` hooks provided by DeepaMehta 4.
